### PR TITLE
ci: add github actions workflow for matrix builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build ${{ matrix.loader }} ${{ matrix.mc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, neoforge]
+        mc: ['1.21.4', '1.21.8', '1.21.11', '26.1.2']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install both JDKs: Gradle itself must run on 25 (26.1.2's Loom checks
+      # the Gradle JVM at config time, and Stonecutter configures every variant
+      # in every job). 1.21.x variants compile with their Java 21 toolchain,
+      # which Gradle auto-detects from the JDK_*_X64 vars setup-java exports.
+      - name: Set up JDK 21 (toolchain for 1.21.x)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up JDK 25 (Gradle JVM, toolchain for 26.1+)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Build ${{ matrix.loader }}:${{ matrix.mc }}
+        run: ./gradlew :${{ matrix.loader }}:${{ matrix.mc }}:build --stacktrace
+
+      - name: Upload jars
+        uses: actions/upload-artifact@v4
+        with:
+          name: alphaskins-${{ matrix.loader }}-${{ matrix.mc }}
+          path: |
+            ${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-sources.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-dev.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-dev-shadow.jar
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,21 +34,21 @@ jobs:
             java: '25'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
       # --configure-on-demand keeps each job from configuring the seven sibling
       # Stonecutter variants. Without it, every job pays Loom's setup cost
@@ -59,7 +59,7 @@ jobs:
         run: ./gradlew :${{ matrix.loader }}:${{ matrix.mc }}:build --configure-on-demand --stacktrace
 
       - name: Upload jars
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: alphaskins-${{ matrix.loader }}-${{ matrix.mc }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,25 +23,24 @@ jobs:
       matrix:
         loader: [fabric, neoforge]
         mc: ['1.21.4', '1.21.8', '1.21.11', '26.1.2']
+        include:
+          - mc: '1.21.4'
+            java: '21'
+          - mc: '1.21.8'
+            java: '21'
+          - mc: '1.21.11'
+            java: '21'
+          - mc: '26.1.2'
+            java: '25'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Install both JDKs: Gradle itself must run on 25 (26.1.2's Loom checks
-      # the Gradle JVM at config time, and Stonecutter configures every variant
-      # in every job). 1.21.x variants compile with their Java 21 toolchain,
-      # which Gradle auto-detects from the JDK_*_X64 vars setup-java exports.
-      - name: Set up JDK 21 (toolchain for 1.21.x)
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
-
-      - name: Set up JDK 25 (Gradle JVM, toolchain for 26.1+)
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '25'
+          java-version: ${{ matrix.java }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -51,8 +50,13 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
 
+      # --configure-on-demand keeps each job from configuring the seven sibling
+      # Stonecutter variants. Without it, every job pays Loom's setup cost
+      # (download MC, decompile, etc.) for all 8 (loader, mc) projects, even
+      # though it only builds one. With it, only the target project configures,
+      # which also means each job only needs its own JDK.
       - name: Build ${{ matrix.loader }}:${{ matrix.mc }}
-        run: ./gradlew :${{ matrix.loader }}:${{ matrix.mc }}:build --stacktrace
+        run: ./gradlew :${{ matrix.loader }}:${{ matrix.mc }}:build --configure-on-demand --stacktrace
 
       - name: Upload jars
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to release (e.g. v5.0.0)
+        required: true
+
+permissions:
+  contents: write
+
+# A release in flight should not be cancelled by a re-run of the same tag.
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build ${{ matrix.loader }} ${{ matrix.mc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, neoforge]
+        mc: ['1.21.4', '1.21.8', '1.21.11', '26.1.2']
+        include:
+          - mc: '1.21.4'
+            java: '21'
+          - mc: '1.21.8'
+            java: '21'
+          - mc: '1.21.11'
+            java: '21'
+          - mc: '26.1.2'
+            java: '25'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Build ${{ matrix.loader }}:${{ matrix.mc }}
+        run: ./gradlew :${{ matrix.loader }}:${{ matrix.mc }}:build --configure-on-demand --stacktrace
+
+      - name: Upload jar
+        uses: actions/upload-artifact@v7
+        with:
+          name: jar-${{ matrix.loader }}-${{ matrix.mc }}
+          path: |
+            ${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-sources.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-dev.jar
+            !${{ matrix.loader }}/versions/${{ matrix.mc }}/build/libs/*-dev-shadow.jar
+          if-no-files-found: error
+
+  github-release:
+    name: gh draft release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all jars
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: jar-*
+          merge-multiple: true
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: ${{ inputs.tag || github.ref_name }}
+          files: dist/*.jar
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+
+  publish:
+    name: publish ${{ matrix.loader }} ${{ matrix.mc }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, neoforge]
+        mc: ['1.21.4', '1.21.8', '1.21.11', '26.1.2']
+    steps:
+      - name: Download jar
+        uses: actions/download-artifact@v8
+        with:
+          name: jar-${{ matrix.loader }}-${{ matrix.mc }}
+          path: dist
+
+      - name: Compute version string
+        id: ver
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          MOD_VERSION="${TAG#v}"
+          echo "mod=${MOD_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "platform=${MOD_VERSION}+${{ matrix.mc }}-${{ matrix.loader }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to Modrinth & CurseForge
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          curseforge-id: ${{ vars.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          files: dist/*.jar
+          name: Alphaskins ${{ steps.ver.outputs.mod }} (${{ matrix.loader }} ${{ matrix.mc }})
+          version: ${{ steps.ver.outputs.platform }}
+          version-type: release
+          loaders: ${{ matrix.loader }}
+          game-versions: ${{ matrix.mc }}
+          retry-attempts: 2
+          fail-mode: fail


### PR DESCRIPTION
builds all 8 (loader, mc) variants in parallel on push/pr to main. each job installs jdk 21 + jdk 25 because stonecutter configures every variant per invocation and 26.1.2's loom requires jdk 25 as the gradle jvm. uploads per-variant jars as artifacts.